### PR TITLE
fix(assets): use absolute deployed URLs for hero poster/video

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,13 +27,13 @@ const metadata = {
     <!-- Simplified hero placeholder to avoid build-time transform issues -->
     <div class="absolute inset-0 w-full h-full">
       <!-- Ensure the poster image is painted early and counted as LCP: high-priority image. Video will overlay it when ready. -->
-      <img id="hero-lcp" src="/assets/hero-poster.webp" fetchpriority="high" decoding="async" class="w-full h-full object-cover absolute inset-0" alt="Hero background poster" aria-hidden="true" />
+      <img id="hero-lcp" src="https://www.workoutquestapp.com/assets/hero-poster.webp" fetchpriority="high" decoding="async" class="w-full h-full object-cover absolute inset-0" alt="Hero background poster" aria-hidden="true" />
 
-      <video id="hero-video" class="w-full h-full object-cover transition-opacity duration-700 opacity-0 pointer-events-none relative" playsinline muted preload="none" poster="/assets/hero-poster.webp" loop>
+      <video id="hero-video" class="w-full h-full object-cover transition-opacity duration-700 opacity-0 pointer-events-none relative" playsinline muted preload="none" poster="https://www.workoutquestapp.com/assets/hero-poster.webp" loop>
         <!-- small device first for bandwidth saving; sources will be added lazily via JS to avoid early downloads -->
-        <source id="hero-source-webm" data-src="/landing.webm" type="video/webm">
+        <source id="hero-source-webm" data-src="https://www.workoutquestapp.com/landing.webm" type="video/webm">
         <!-- Fallback for very old browsers -->
-        <img src="/assets/hero-poster.webp" alt="Hero background poster" />
+        <img src="https://www.workoutquestapp.com/assets/hero-poster.webp" alt="Hero background poster" />
       </video>
     </div>
 


### PR DESCRIPTION
Use absolute URLs to the deployed site for hero poster and lazy-loaded video sources so the deployed HTML requests assets from the correct host/path. This is a safe temporary fix; we can later migrate to build-time asset imports if preferred.